### PR TITLE
fix(size-labels): not using custom labels maybe due to not including the missing category `xxl`

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -11,13 +11,19 @@ M:
   lines: 100
   color: FBCA04
 L:
-  name: '🦑 size: large'
+  name: '🐘 size: large'
   lines: 500
   color: D93F0B
 XL:
   name: '🐋 size: x-large'
   lines: 1000
   color: B60205
+  comment: |
+    # whoa! easy there, partner!
+    this pull request is too big. please break it up into smaller pull requests unless this is an exceptional case.
+XXL:
+  name: '🦑 size: xx-large'
+  lines: 5000
   comment: |
     # whoa! easy there, partner!
     this pull request is too big. please break it up into smaller pull requests unless this is an exceptional case.


### PR DESCRIPTION
## 🎯 Changes

- added the missing category the `xxl` in the `labels.yaml` app bot configuration to try to fix the issue of not using the defined custom labels

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/saud-alnasser/starflux/blob/main/CONTRIBUTING.md).
- [x] I have added or updated the tests related to the changes made.
- [x] If necessary, I have added documentation related to the changes made.
