### PR TITLE
fix(size-labels): add missing color property for the `xxl` size

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -17,13 +17,14 @@ L:
 XL:
   name: '🐋 size: x-large'
   lines: 1000
-  color: B60205
+  color: B60560
   comment: |
     # whoa! easy there, partner!
     this pull request is too big. please break it up into smaller pull requests unless this is an exceptional case.
 XXL:
   name: '🦑 size: xx-large'
   lines: 5000
+  color: B60205
   comment: |
     # whoa! easy there, partner!
     this pull request is too big. please break it up into smaller pull requests unless this is an exceptional case.


### PR DESCRIPTION
## 🎯 Changes

- added the missing color property for the `xxl` size configuration

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/saud-alnasser/starflux/blob/main/CONTRIBUTING.md).
- [x] I have added or updated the tests related to the changes made.
- [x] If necessary, I have added documentation related to the changes made.
