### PR TITLE
ci: limit the `📚 type: documentation` label to `md` or `mdx` file changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,8 +5,8 @@
   - any: ['www/**/*']
 
 '📚 type: documentation':
-  - any: ['www/**/*']
   - any: ['**/*.md']
+  - any: ['**/*.mdx']
 
 '🔧 type: development tools':
   - any: ['.changeset/**/*']


### PR DESCRIPTION
## 🎯 Changes

- limited the usage of the `📚 type: documentation` label to pull requests that contains `md` or `mdx` file changes

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/saud-alnasser/starflux/blob/main/CONTRIBUTING.md).
- [x] I have added or updated the tests related to the changes made.
- [x] If necessary, I have added documentation related to the changes made.
